### PR TITLE
drop boost preferred as first maxed boost for gatherers

### DIFF
--- a/guides/gatherer.md
+++ b/guides/gatherer.md
@@ -9,7 +9,7 @@ by Kalesaur
 
 ## Premium store
 
-- res boost = drop boost > exp > mastery
+- drop boost > res boost > exp > mastery
 - Max each boost before moving on to the next
 
 ## Gathering upgrades


### PR DESCRIPTION
for most of players is more effective to have drop boost maxed first